### PR TITLE
Better Auto Eat

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ A Collection of Minecraft Bots written in rust mainly developed for `2b2t.org`.
 > which has more features and fixes.
 
 ## Plugins
-1. [Anti AFK](./plugins/anti-afk) Anti AFK Plugin with advanced configuration which attemps to not get the bot afk kicked.
+1. [Anti AFK](./plugins/anti-afk) Anti AFK Plugin with advanced configuration which attempts to not get the bot afk kicked.
 2. [Auto Mine](./plugins/auto-mine) Left Click implementation, when enabled this block will mine anything it is looking at
 if reachable. Also available in [#156](https://github.com/azalea-rs/azalea/pull/156) PR in azalea.
 3. [Discord](./plugins/discord) A small plugin that is the bridge between the bot and discord. This plugin can also bridge
 logs.
-4. [Task Manager](./plugins/task-manager) A small task manager that executes task one by one. Currently it only supports,
+4. [Task Manager](./plugins/task-manager) A small task manager that executes task one by one. Currently, it only supports,
 a small number of tasks.
-5. [Utility](./plugins/utility) A small collection of plugins that are essential for bot survial. It includes Auto Eat, and
-Kill Aura.
+5. [Utility](./plugins/utility) A small collection of plugins that are essential for bot survival. It includes Auto Eat, and
+Kill Aura (WIP).
 
 ## Examples
-1. [Anti AFK](./examples/anti-afk) This bot attempts to join the server, and simply tries to not get AFK kicked.
+1. [Anti AFK](./examples/anti-afk) This bot attempts to join the server, and simply tries to not get AFK kicked and also
+    not die of hunger.
 2. [Stone Miner](./examples/stone-miner) This bot is specifically designed for mining stones in a stone generator at
 craftmc.pl for my friend.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ The bots here may be created for experimentation and can also come in the main b
 
 1. [**Stone Miner**](./stone-miner) - This bot mines stone in a stone generator that generates stone using command 
     blocks. This bot is on Minecraft Version `1.20.6`.
-2. [**Anti-AFK**](./anti-afk) - This bot joins the server and does some actions to not get AFK Kicked/
+2. [**Anti-AFK**](./anti-afk) - This bot joins the server and does some actions to not get AFK Kicked and
+    also supports auto eat functionality.
 
 _More bots will be coming soon._

--- a/examples/anti-afk/Cargo.toml
+++ b/examples/anti-afk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 azalea = { git = "https://github.com/as1100k-forks/azalea.git", branch = "better-1.20.6" }
 azalea-anti-afk = { path = "../../plugins/anti-afk" }
+azalea-utility = { path = "../../plugins/utility" }
 parking_lot = "0.12.3"
 tokio = "1.38.0"
 anyhow = "1.0.86"

--- a/examples/anti-afk/src/main.rs
+++ b/examples/anti-afk/src/main.rs
@@ -2,6 +2,8 @@ use azalea::prelude::*;
 use azalea::Vec3;
 use azalea_anti_afk::config::AntiAFKConfig;
 use azalea_anti_afk::{AntiAFKClientExt, AntiAFKPlugin};
+use azalea_utility::client::UtilityExt;
+use azalea_utility::UtilityPlugin;
 
 #[tokio::main]
 async fn main() {
@@ -10,7 +12,8 @@ async fn main() {
     ClientBuilder::new()
         .set_handler(handle)
         .add_plugins(AntiAFKPlugin)
-        .start(account, "10.9.12.3")
+        .add_plugins(UtilityPlugin)
+        .start(account, "localhost")
         .await
         .unwrap();
 }
@@ -29,6 +32,9 @@ async fn handle(bot: Client, event: Event, _state: State) -> anyhow::Result<()> 
                 central_afk_location: Some(Vec3::new(0f64, 0f64, 0f64)),
             };
             bot.set_anti_afk(true, Some(anti_afk_config));
+        }
+        Event::Login => {
+            bot.set_auto_eat(Some(Default::default()))
         }
         Event::Chat(m) => {
             println!("{}", m.message().to_ansi());

--- a/plugins/utility/src/auto_eat/food.rs
+++ b/plugins/utility/src/auto_eat/food.rs
@@ -1,14 +1,11 @@
 use std::collections::HashMap;
-use azalea::registry::{Item, MobEffect};
+use azalea::registry::Item;
 
 /// List of Food items that can be consumed
 pub(super) struct Foods(pub HashMap<Item, FoodInfo>);
 
 pub(super) struct FoodInfo {
     pub(super) food_points: f32,
-    pub(super) saturation_restored: f32,
-    pub(super) saturation_ratio: f32,
-    pub(super) effect: Vec<MobEffect>,
     pub(super) nourishment: Nourishment,
 }
 
@@ -51,14 +48,6 @@ impl Default for Foods {
             Item::EnchantedGoldenApple,
             FoodInfo {
                 food_points: 4.0,
-                saturation_restored: 9.6,
-                saturation_ratio: 2.4,
-                effect: vec![
-                    MobEffect::Absorption,
-                    MobEffect::Regeneration,
-                    MobEffect::Resistance,
-                    MobEffect::FireResistance,
-                ],
                 nourishment: Nourishment::Great,
             },
         );
@@ -67,9 +56,6 @@ impl Default for Foods {
             Item::GoldenApple,
             FoodInfo {
                 food_points: 4.0,
-                saturation_restored: 9.6,
-                saturation_ratio: 2.4,
-                effect: vec![MobEffect::Regeneration, MobEffect::Absorption],
                 nourishment: Nourishment::Great,
             },
         );
@@ -78,9 +64,6 @@ impl Default for Foods {
             Item::GoldenCarrot,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 14.4,
-                saturation_ratio: 2.4,
-                effect: vec![],
                 nourishment: Nourishment::Great,
             },
         );
@@ -91,9 +74,6 @@ impl Default for Foods {
             Item::CookedMutton,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 9.6,
-                saturation_ratio: 1.6,
-                effect: vec![],
                 nourishment: Nourishment::Good,
             },
         );
@@ -102,9 +82,6 @@ impl Default for Foods {
             Item::CookedPorkchop,
             FoodInfo {
                 food_points: 8.0,
-                saturation_restored: 12.8,
-                saturation_ratio: 1.6,
-                effect: vec![],
                 nourishment: Nourishment::Good,
             },
         );
@@ -113,9 +90,6 @@ impl Default for Foods {
             Item::CookedSalmon,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 9.6,
-                saturation_ratio: 1.6,
-                effect: vec![],
                 nourishment: Nourishment::Good,
             },
         );
@@ -124,9 +98,6 @@ impl Default for Foods {
             Item::CookedBeef,
             FoodInfo {
                 food_points: 8.0,
-                saturation_restored: 12.8,
-                saturation_ratio: 1.6,
-                effect: vec![],
                 nourishment: Nourishment::Good,
             },
         );
@@ -137,9 +108,6 @@ impl Default for Foods {
             Item::BakedPotato,
             FoodInfo {
                 food_points: 5.0,
-                saturation_restored: 6.0,
-                saturation_ratio: 0.0,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -148,9 +116,6 @@ impl Default for Foods {
             Item::Beetroot,
             FoodInfo {
                 food_points: 1.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -159,9 +124,6 @@ impl Default for Foods {
             Item::BeetrootSoup,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 7.2,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -170,9 +132,6 @@ impl Default for Foods {
             Item::Bread,
             FoodInfo {
                 food_points: 5.0,
-                saturation_restored: 6.0,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -181,9 +140,6 @@ impl Default for Foods {
             Item::Carrot,
             FoodInfo {
                 food_points: 3.0,
-                saturation_restored: 3.6,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -192,9 +148,6 @@ impl Default for Foods {
             Item::CookedChicken,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 7.2,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -203,9 +156,6 @@ impl Default for Foods {
             Item::CookedCod,
             FoodInfo {
                 food_points: 5.0,
-                saturation_restored: 6.0,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -214,9 +164,6 @@ impl Default for Foods {
             Item::CookedRabbit,
             FoodInfo {
                 food_points: 5.0,
-                saturation_restored: 6.0,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -225,9 +172,6 @@ impl Default for Foods {
             Item::MushroomStew,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 7.2,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -236,9 +180,6 @@ impl Default for Foods {
             Item::RabbitStew,
             FoodInfo {
                 food_points: 10.0,
-                saturation_restored: 12.0,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -247,9 +188,6 @@ impl Default for Foods {
             Item::SuspiciousStew,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 7.2,
-                saturation_ratio: 1.2,
-                effect: vec![],
                 nourishment: Nourishment::Normal,
             },
         );
@@ -260,9 +198,6 @@ impl Default for Foods {
             Item::Apple,
             FoodInfo {
                 food_points: 4.0,
-                saturation_restored: 2.4,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -282,9 +217,6 @@ impl Default for Foods {
             Item::DriedKelp,
             FoodInfo {
                 food_points: 1.0,
-                saturation_restored: 0.6,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -293,31 +225,25 @@ impl Default for Foods {
             Item::MelonSlice,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
-        // 5. Poisonous Potato
-        foods.insert(
-            Item::PoisonousPotato,
-            FoodInfo {
-                food_points: 2.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 0.6,
-                effect: vec![MobEffect::Poison],
-                nourishment: Nourishment::Low,
-            },
-        );
+        // 5. Poisonous Potato (Not Supported)
+        // foods.insert(
+        //     Item::PoisonousPotato,
+        //     FoodInfo {
+        //         food_points: 2.0,
+        //         saturation_restored: 1.2,
+        //         saturation_ratio: 0.6,
+        //         effect: vec![MobEffect::Poison],
+        //         nourishment: Nourishment::Low,
+        //     },
+        // );
         // 6. Potato
         foods.insert(
             Item::Potato,
             FoodInfo {
                 food_points: 1.0,
-                saturation_restored: 1.6,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -326,9 +252,6 @@ impl Default for Foods {
             Item::PumpkinPie,
             FoodInfo {
                 food_points: 8.0,
-                saturation_restored: 4.8,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -337,31 +260,25 @@ impl Default for Foods {
             Item::Beef,
             FoodInfo {
                 food_points: 3.0,
-                saturation_restored: 1.8,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
-        // 9. Raw Chicken
-        foods.insert(
-            Item::Chicken,
-            FoodInfo {
-                food_points: 2.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 0.6,
-                effect: vec![MobEffect::Hunger],
-                nourishment: Nourishment::Low,
-            },
-        );
+        // 9. Raw Chicken (Not Supported)
+        // foods.insert(
+        //     Item::Chicken,
+        //     FoodInfo {
+        //         food_points: 2.0,
+        //         saturation_restored: 1.2,
+        //         saturation_ratio: 0.6,
+        //         effect: vec![MobEffect::Hunger],
+        //         nourishment: Nourishment::Low,
+        //     },
+        // );
         // 10. Raw Mutton
         foods.insert(
             Item::Mutton,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -370,9 +287,6 @@ impl Default for Foods {
             Item::Porkchop,
             FoodInfo {
                 food_points: 3.0,
-                saturation_restored: 1.8,
-                saturation_ratio: 0.6,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -381,9 +295,6 @@ impl Default for Foods {
             Item::SweetBerries,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 0.4,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Low,
             },
         );
@@ -405,9 +316,6 @@ impl Default for Foods {
             Item::Cookie,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 0.4,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Poor,
             },
         );
@@ -416,9 +324,6 @@ impl Default for Foods {
             Item::GlowBerries,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 0.4,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Poor,
             },
         );
@@ -427,33 +332,25 @@ impl Default for Foods {
             Item::HoneyBottle,
             FoodInfo {
                 food_points: 6.0,
-                saturation_restored: 1.2,
-                saturation_ratio: 0.2,
-                effect: vec![
-                    // Clears Poison
-                ],
                 nourishment: Nourishment::Poor,
             },
         );
-        // 5. Pufferfish
-        foods.insert(
-            Item::Pufferfish,
-            FoodInfo {
-                food_points: 1.0,
-                saturation_restored: 0.2,
-                saturation_ratio: 0.2,
-                effect: vec![MobEffect::Hunger, MobEffect::Nausea, MobEffect::Poison],
-                nourishment: Nourishment::Poor,
-            },
-        );
+        // 5. Pufferfish (Not Supported)
+        // foods.insert(
+        //     Item::Pufferfish,
+        //     FoodInfo {
+        //         food_points: 1.0,
+        //         saturation_restored: 0.2,
+        //         saturation_ratio: 0.2,
+        //         effect: vec![MobEffect::Hunger, MobEffect::Nausea, MobEffect::Poison],
+        //         nourishment: Nourishment::Poor,
+        //     },
+        // );
         // 6. Raw Cod
         foods.insert(
             Item::Cod,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 0.4,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Poor,
             },
         );
@@ -462,42 +359,36 @@ impl Default for Foods {
             Item::Salmon,
             FoodInfo {
                 food_points: 2.0,
-                saturation_restored: 0.4,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Poor,
             },
         );
-        // 8. Rotten Flesh
-        foods.insert(
-            Item::RottenFlesh,
-            FoodInfo {
-                food_points: 4.0,
-                saturation_restored: 0.8,
-                saturation_ratio: 0.2,
-                effect: vec![MobEffect::Hunger],
-                nourishment: Nourishment::Poor,
-            },
-        );
-        // 9. Spider Eye
-        foods.insert(
-            Item::SpiderEye,
-            FoodInfo {
-                food_points: 2.0,
-                saturation_restored: 3.2,
-                saturation_ratio: 1.6,
-                effect: vec![MobEffect::Poison],
-                nourishment: Nourishment::Poor,
-            },
-        );
+        // 8. Rotten Flesh (Not Supported)
+        // foods.insert(
+        //     Item::RottenFlesh,
+        //     FoodInfo {
+        //         food_points: 4.0,
+        //         saturation_restored: 0.8,
+        //         saturation_ratio: 0.2,
+        //         effect: vec![MobEffect::Hunger],
+        //         nourishment: Nourishment::Poor,
+        //     },
+        // );
+        // 9. Spider Eye (Not Supported)
+        // foods.insert(
+        //     Item::SpiderEye,
+        //     FoodInfo {
+        //         food_points: 2.0,
+        //         saturation_restored: 3.2,
+        //         saturation_ratio: 1.6,
+        //         effect: vec![MobEffect::Poison],
+        //         nourishment: Nourishment::Poor,
+        //     },
+        // );
         // 10. Tropical Fish
         foods.insert(
             Item::TropicalFish,
             FoodInfo {
                 food_points: 1.0,
-                saturation_restored: 0.2,
-                saturation_ratio: 0.2,
-                effect: vec![],
                 nourishment: Nourishment::Poor,
             },
         );

--- a/plugins/utility/src/auto_eat/mod.rs
+++ b/plugins/utility/src/auto_eat/mod.rs
@@ -161,8 +161,19 @@ fn handle_chane_in_inventory(
 
         // This is guaranteed to be `Menu::Player`
         if let Menu::Player(player) = menu {
-            let inventory = &player.inventory;
-            for item_slot in inventory.iter() {
+            let inventory = &player.inventory.iter();
+
+            // Searchable slots that should be searched.
+            // NOTE: offhand slot is always included.
+            let searchable_slots: dyn Iterator<Item=ItemSlot> = if auto_eat.use_inventory {
+                // Ignore slots from 0 to 8 as they are either of armor or crafting
+                inventory.to_owned().skip(8)
+            } else {
+                // Skips the entire inventory except hotbar
+                inventory.to_owned().skip(35)
+            };
+
+            for item_slot in searchable_slots {
                 if let ItemSlot::Present(item_slot_data) = item_slot {
                     let item = item_slot_data.kind;
                     if auto_eat.foods.0.contains_key(&item) {

--- a/plugins/utility/src/auto_eat/mod.rs
+++ b/plugins/utility/src/auto_eat/mod.rs
@@ -108,8 +108,6 @@ fn handle_auto_eat(
     mut query: Query<
         (
             Entity,
-            &MinecraftEntityId,
-            &ShiftKeyDown,
             &mut AutoEat,
             &mut InventoryComponent,
             &Hunger,
@@ -121,8 +119,6 @@ fn handle_auto_eat(
 ) {
     for (
         entity,
-        minecraft_entity_id,
-        shift_key_down,
         mut auto_eat,
         mut inventory_component,
         hunger,

--- a/plugins/utility/src/auto_eat/mod.rs
+++ b/plugins/utility/src/auto_eat/mod.rs
@@ -3,7 +3,7 @@ mod food;
 use crate::auto_eat::food::Foods;
 use azalea::app::{App, Plugin, Update};
 use azalea::ecs::prelude::*;
-use azalea::entity::metadata::Player;
+use azalea::entity::metadata::{Health, Player};
 use azalea::entity::LocalEntity;
 use azalea::interact::CurrentSequenceNumber;
 use azalea::inventory::operations::{ClickOperation, SwapClick};
@@ -122,6 +122,7 @@ fn handle_auto_eat(
             &mut AutoEat,
             &InventoryComponent,
             &Hunger,
+            &Health,
             &CurrentSequenceNumber,
         ),
         (With<AutoEat>, With<LocalEntity>, With<Player>),
@@ -130,13 +131,12 @@ fn handle_auto_eat(
     mut container_click_event: EventWriter<ContainerClickEvent>,
     mut set_selected_hotbar_slot_event: EventWriter<SetSelectedHotbarSlotEvent>,
 ) {
-    for (entity, mut auto_eat, inventory_component, hunger, current_sequence_number) in
+    for (entity, mut auto_eat, inventory_component, hunger, health, current_sequence_number) in
         query.iter_mut()
     {
-        if hunger.food <= (20 - auto_eat.max_hunger as u32)
+        if (hunger.food <= (20 - auto_eat.max_hunger as u32) || health.0 <= 10f32)
             && auto_eat.mini_task != MiniTask::SearchFoodInChests
         {
-            println!("Hunger -> {}", hunger.food);
             if let Some(next_food_to_eat) = &auto_eat.next_food_to_eat {
                 // If 7th slot in hot bar isn't selected, select it
                 if inventory_component.selected_hotbar_slot != 7 {

--- a/plugins/utility/src/lib.rs
+++ b/plugins/utility/src/lib.rs
@@ -6,7 +6,6 @@ pub mod client;
 
 use crate::auto_eat::AutoEatPlugin;
 use azalea::app::{PluginGroup, PluginGroupBuilder};
-use azalea::ecs::prelude::*;
 
 /// Collection of basic utility plugins
 pub struct UtilityPlugin;


### PR DESCRIPTION
This PR adds/fixes the following things:
* Added Health as condition to eat
* Removed unnecessary fields inside food
* fixed inventory search loop which occurs when bot moves food from inventory to hotbar
* fixed wrong inventory slot offset
* Added Auto Eat to Anti-AFK Example 